### PR TITLE
Update to numpy 2and scikit-sparse version requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ requirements:
     - setuptools >=61.0.0
   run:
     - nibabel
-    - numpy >=1.22
+    - numpy >=2
     - plotly
     - psutil
     - python >={{ python_min }}
-    - scikit-sparse
+    - scikit-sparse >=0.4.16
     - scipy
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
scikit-sparse supports numpy 2 since version 0.4.16 (for python versions 3.9 and up). This PR updates the dependency version requirements to move to numpy 2 . 

This is in preparation for the next upstream release.
No rebuild is intended for the current version; changes will take effect on the next version bump. Therefore no version or build number is changed. 