### PR TITLE
Revert numpy and scikit-sparse version requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ requirements:
     - setuptools >=61.0.0
   run:
     - nibabel
-    - numpy >=2
+    - numpy >=1.22
     - plotly
     - psutil
     - python >={{ python_min }}
-    - scikit-sparse >=0.4.16
+    - scikit-sparse
     - scipy
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Reverting numpy bump as the code works on older numpy and we do not (yet) want to exclude users who need numpy 1 for other reasons. 